### PR TITLE
Specify page titles in front matter

### DIFF
--- a/_pages/article-10.md
+++ b/_pages/article-10.md
@@ -1,5 +1,5 @@
 ---
-title: "Article 10 – Placeholder"
+title: "Article X – Miscellaneous Provisions"
 permalink: /article-10/
 ---
 

--- a/_pages/article-3.md
+++ b/_pages/article-3.md
@@ -1,5 +1,5 @@
 ---
-title: "Article 3 – Placeholder"
+title: "Article III – Use Districts"
 permalink: /article-3/
 ---
 

--- a/_pages/article-4.md
+++ b/_pages/article-4.md
@@ -1,5 +1,5 @@
 ---
-title: "Article 4 – Placeholder"
+title: "Article IV – Overlay Districts"
 permalink: /article-4/
 ---
 

--- a/_pages/article-5.md
+++ b/_pages/article-5.md
@@ -1,5 +1,5 @@
 ---
-title: "Article 5 – Placeholder"
+title: "Article V – Subdivisions and Planned Developments"
 permalink: /article-5/
 ---
 

--- a/_pages/article-6.md
+++ b/_pages/article-6.md
@@ -1,5 +1,5 @@
 ---
-title: "Article 6 – Placeholder"
+title: "Article VI – Additional Standards for Specific Uses"
 permalink: /article-6/
 ---
 

--- a/_pages/article-7.md
+++ b/_pages/article-7.md
@@ -1,5 +1,5 @@
 ---
-title: "Article 7 – Placeholder"
+title: "Article VII – Non-conformities"
 permalink: /article-7/
 ---
 

--- a/_pages/article-8.md
+++ b/_pages/article-8.md
@@ -1,5 +1,5 @@
 ---
-title: "Article 8 – Placeholder"
+title: "Article VIII – Board of Adjustment"
 permalink: /article-8/
 ---
 

--- a/_pages/article-9.md
+++ b/_pages/article-9.md
@@ -1,5 +1,5 @@
 ---
-title: "Article 9 – Placeholder"
+title: "Article IX – Administration and Enforcement"
 permalink: /article-9/
 ---
 


### PR DESCRIPTION
## Summary
- update the `title` field in article pages to reflect the page heading

## Testing
- `bundle exec jekyll build`