### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ For the legally binding ordinance, visit [https://lebanonnh.gov/zoningordinance]
 
 The pages in the `_pages/` directory mirror sections of the ordinance so that they can be viewed using the Just the Docs theme. Content here may be incomplete or outdated as we test formatting and workflow options.
 
+The site also includes an optional **dark mode**. Use the toggle in the page header to switch between light and dark themes.
+
 ## Building Locally
 
 1. Install [Jekyll](https://jekyllrb.com) and [Bundler](https://bundler.io).

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,26 @@
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var toggle = document.getElementById('theme-toggle');
+    function updateText(theme) {
+      if (toggle) {
+        toggle.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+      }
+    }
+    var stored = localStorage.getItem('theme');
+    if (stored) {
+      jtd.setTheme(stored);
+      updateText(stored);
+    } else {
+      updateText(jtd.getTheme());
+    }
+    if (toggle) {
+      toggle.addEventListener('click', function () {
+        var current = jtd.getTheme();
+        var next = current === 'dark' ? 'default' : 'dark';
+        jtd.setTheme(next);
+        localStorage.setItem('theme', next);
+        updateText(next);
+      });
+    }
+  });
+</script>

--- a/_includes/header_custom.html
+++ b/_includes/header_custom.html
@@ -1,0 +1,1 @@
+<button id="theme-toggle" style="margin-left:1rem">Dark Mode</button>


### PR DESCRIPTION
## Summary
- add a dark mode toggle button in header
- load stored theme preference and handle toggle via script
- document the new feature

## Testing
- `bundle exec jekyll build`