### PR TITLE
Switch to remote theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,8 @@ gem "jekyll", "~> 4.4.1" # installed by `gem jekyll`
 gem "just-the-docs", "0.10.1" # pinned to the current release
 # gem "just-the-docs"        # always download the latest release
 
+# Required when using the theme as a remote theme
+gem "jekyll-remote-theme"
+
 # Logging utility
 gem "logger"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The site also includes an optional **dark mode**. Use the toggle in the page hea
 2. Run `bundle install`.
 3. Run `bundle exec jekyll serve` and open `http://localhost:4000` to preview the site.
 
+If you encounter an error stating that the `just-the-docs` theme could not be found, make sure you are running Jekyll via Bundler so the required gems are loaded.
+
 ## License
 
 This project is released under the [MIT License](LICENSE).

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,9 @@
 amotitle: City of Lebanon, NH Zoning Ordinance (Beta)
 description: Exploring the use of Github Pages for our zoning ordinance.
-theme: just-the-docs
+remote_theme: just-the-docs/just-the-docs
+plugins:
+  - jekyll-remote-theme
+  - just-the-docs
 
 url: https://melbamorph.github.io/zoning
 


### PR DESCRIPTION
## Summary
- use just-the-docs via remote_theme
- document how to fix the missing theme error

## Testing
- `bundle exec jekyll build` *(fails: Could not find gem 'jekyll-remote-theme' in cached gems)*