### PR TITLE
Remove top navigation dark mode button

### DIFF
--- a/_includes/header_custom.html
+++ b/_includes/header_custom.html
@@ -1,1 +1,0 @@
-<button id="theme-toggle" style="margin-left:1rem">Dark Mode</button>


### PR DESCRIPTION
## Summary
- remove the dark mode toggle from the header

## Testing
- `bundle exec jekyll build`