### PR TITLE
Add search term highlight on pages

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,3 +1,4 @@
+<script src="{{ '/assets/js/search-highlight.js' | relative_url }}"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function () {
     var toggle = document.getElementById('theme-toggle');

--- a/assets/js/search-highlight.js
+++ b/assets/js/search-highlight.js
@@ -1,0 +1,61 @@
+(function(){
+  function escapeRegExp(str){
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  function highlightTerms(terms){
+    if(!terms.length) return;
+    var container = document.getElementById('main-content') || document.body;
+    var walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
+      acceptNode: function(node){
+        var parent = node.parentNode;
+        while(parent){
+          if(parent.nodeType !== 1) break;
+          var tag = parent.tagName;
+          if(['SCRIPT','STYLE','CODE','PRE','NOSCRIPT'].indexOf(tag) !== -1){
+            return NodeFilter.FILTER_REJECT;
+          }
+          parent = parent.parentNode;
+        }
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    });
+    var nodes = [];
+    while(walker.nextNode()) nodes.push(walker.currentNode);
+    nodes.forEach(function(node){
+      var text = node.nodeValue;
+      var replaced = text;
+      var matched = false;
+      terms.forEach(function(term){
+        var regex = new RegExp('(' + escapeRegExp(term) + ')', 'gi');
+        if(regex.test(replaced)){
+          matched = true;
+          replaced = replaced.replace(regex, '<mark>$1</mark>');
+        }
+      });
+      if(matched){
+        var span = document.createElement('span');
+        span.innerHTML = replaced;
+        node.parentNode.replaceChild(span, node);
+      }
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function(){
+    var searchInput = document.getElementById('search-input');
+    if(searchInput){
+      document.addEventListener('click', function(e){
+        var link = e.target.closest('.search-result');
+        if(link && searchInput.value){
+          localStorage.setItem('jtd_search_terms', searchInput.value);
+        }
+      });
+    }
+    var saved = localStorage.getItem('jtd_search_terms');
+    if(saved){
+      localStorage.removeItem('jtd_search_terms');
+      var terms = saved.split(/\s+/).filter(Boolean);
+      highlightTerms(terms);
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- inject a small script to store the search query and highlight terms when the destination page loads
- include new script in `head_custom.html`

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_6855bf7d9ed88320ad22c02ba39f5b19